### PR TITLE
Some tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,7 @@ find_program(ASTYLE astyle)
 
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Weffc++ -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wabi -Wmissing-declarations -Wconversion -Wcast-align -Wredundant-decls -Werror -pedantic")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Weffc++ -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wabi -Wmissing-declarations -Wconversion -Wcast-align -Wredundant-decls -Werror -pedantic")
 endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ cmake_minimum_required(VERSION 2.6)
 
 project(oaconvert CXX)
 
+find_program(ASTYLE astyle)
+
+
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Weffc++ -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wabi -Wmissing-declarations -Wconversion -Wcast-align -Wredundant-decls -Werror -pedantic")
@@ -25,17 +28,19 @@ endif()
 add_subdirectory(src)
 add_subdirectory(test)
 
-add_custom_target(reformat
-                  astyle --options=astyle_options src/*.cpp src/*.h
-                  COMMENT "Beautifying CPP source files"
-                  VERBATIM)
+if(ASTYLE)
+    add_custom_target(reformat
+                      ${ASTYLE} --options=astyle_options src/*.cpp src/*.h 
+                      COMMENT "Beautifying CPP source files"
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                      VERBATIM)
 
-# TODO: this is not working yet, fix it.  The problem is
-#       the quotes around "*.orig" when typing `make origclean`.
-#add_custom_target(origclean
-#                  rm -f *.orig
-#                  COMMENT "Removing astyle backup files"
-#                  WORKING_DIRECTORY src
-#                  VERBATIM)
+    add_custom_target(origclean
+                      rm -f *.orig
+                      COMMENT "Removing astyle backup files"
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src)
+else()
+    message(WARNING "Could not find astyle. To be able to beautify the source code, install it from http://astyle.sourceforge.net/.")
+endif()
 
 # vim: expandtab

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 2.6)
 project(oaconvert CXX)
 
 find_program(ASTYLE astyle)
+find_library(CPPUNIT LIBRARY
+    NAMES cppunit)
 
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -25,7 +27,15 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif()
 
 add_subdirectory(src)
-add_subdirectory(test)
+
+# Only compile the unit tests if cppunit is available or if we know that we can
+# compile it ourselves.
+if(CPPUNIT OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  add_subdirectory(test)
+else()
+  message(WARNING "Cppunit was not found and we could not compile it "
+                  "automatically ourselves. Unit testing will be disabled.")
+endif()
 
 if(ASTYLE)
     add_custom_target(reformat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_program(ASTYLE astyle)
 
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Weffc++ -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wabi -Wmissing-declarations -Wconversion -Wcast-align -Wredundant-decls -Werror -pedantic")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Weffc++ -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wabi -Wmissing-declarations -Wconversion -Wcast-align -Wredundant-decls -pedantic")
 endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,21 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 cmake_minimum_required(VERSION 2.6)
 
-project(oaconvert)
+project(oaconvert CXX)
 
-# Uncomment this to use clang for compiling.
-SET (CMAKE_CXX_COMPILER "/usr/bin/clang++-3.5")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Weffc++ -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wabi -Wmissing-declarations -Wconversion -Wcast-align -Wredundant-decls -Werror -pedantic")
+endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++14 -stdlib=libc++ -g")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Weffc++ -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wabi -Wmissing-declarations -Wconversion -Wcast-align -Wredundant-decls -Werror -pedantic")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(GCC_MIN_VER "4.9")
+    if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "${GCC_MIN_VER}")
+        message(FATAL_ERROR "GCC version should be at least ${GCC_MIN_VER}!")
+    endif()
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
 
 add_subdirectory(src)
 add_subdirectory(test)
@@ -29,3 +37,5 @@ add_custom_target(reformat
 #                  COMMENT "Removing astyle backup files"
 #                  WORKING_DIRECTORY src
 #                  VERBATIM)
+
+# vim: expandtab

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,14 +28,7 @@ endif()
 
 add_subdirectory(src)
 
-# Only compile the unit tests if cppunit is available or if we know that we can
-# compile it ourselves.
-if(CPPUNIT OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  add_subdirectory(test)
-else()
-  message(WARNING "Cppunit was not found and we could not compile it "
-                  "automatically ourselves. Unit testing will be disabled.")
-endif()
+add_subdirectory(test)
 
 if(ASTYLE)
     add_custom_target(reformat

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,6 @@ set(oaconvert_SRCS
     oaconvert.cpp
 )
 
-add_library(airspace SHARED ${airspace_SRCS})
+add_library(airspace STATIC ${airspace_SRCS})
 add_executable(oaconvert ${oaconvert_SRCS})
 target_link_libraries(oaconvert airspace)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,30 @@
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # When building with Clang, we need to compile cppunit ourselves or we get
+    # linking errors...
+    include(ExternalProject)
+    ExternalProject_Add(
+        cppunit_external
+        CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        PREFIX ${CMAKE_BINARY_DIR}/cppunit
+        URL http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz
+        URL_MD5 d1c6bdd5a76c66d2c38331e2d287bc01
+        CONFIGURE_COMMAND sh -c "<SOURCE_DIR>/configure --prefix=<INSTALL_DIR> CXX=${CMAKE_CXX_COMPILER} CXXFLAGS='${CMAKE_CXX_FLAGS}' ${PACKAGE_COMPILER_FLAGS} ${PACKAGE_CONFIGURE_FLAGS}"
+#        GIT_REPOSITORY git://anongit.freedesktop.org/git/libreoffice/cppunit/
+#        GIT_TAG cppunit-1.13.2
+#        CONFIGURE_COMMAND sh -c "<SOURCE_DIR>/autogen.sh && <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> CXX=${CMAKE_CXX_COMPILER} CXXFLAGS='${CMAKE_CXX_FLAGS}' ${PACKAGE_COMPILER_FLAGS} ${PACKAGE_CONFIGURE_FLAGS}"
+        BUILD_IN_SOURCE 1
+        BUILD_COMMAND make
+        INSTALL_COMMAND make install
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        )
+
+    ExternalProject_Get_Property(cppunit_external install_dir)
+    add_library(cppunit STATIC IMPORTED)
+    set_property(TARGET cppunit PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libcppunit.a)
+endif()
+
 include_directories("../src")
 
 set(MainTest_SRCS
@@ -12,4 +39,11 @@ set(MainTest_SRCS
 )
 
 add_executable(MainTest ${MainTest_SRCS})
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    add_dependencies(MainTest cppunit_external)
+endif()
+
 target_link_libraries(MainTest cppunit airspace)
+
+# vim: expandtab

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR 
+        (NOT CPPUNIT AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC"))
     # When building with Clang, we need to compile cppunit ourselves or we get
     # linking errors...
     include(ExternalProject)
@@ -25,25 +26,30 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set_property(TARGET cppunit PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libcppunit.a)
 endif()
 
-include_directories("../src")
+if(CPPUNIT)
+    include_directories("../src")
 
-set(MainTest_SRCS
-    ArcTest.cpp
-    LatLonTest.cpp
-    LatitudeTest.cpp
-    LongitudeTest.cpp
-    CoordinateTest.cpp
-    MainTester.cpp
-    ParserTest.cpp
-    AirspaceTest.cpp
-)
+    set(MainTest_SRCS
+        ArcTest.cpp
+        LatLonTest.cpp
+        LatitudeTest.cpp
+        LongitudeTest.cpp
+        CoordinateTest.cpp
+        MainTester.cpp
+        ParserTest.cpp
+        AirspaceTest.cpp
+    )
 
-add_executable(MainTest ${MainTest_SRCS})
+    add_executable(MainTest ${MainTest_SRCS})
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_dependencies(MainTest cppunit_external)
+    if(TARGET cppunit_external)
+        add_dependencies(MainTest cppunit_external)
+    endif()
+
+    target_link_libraries(MainTest cppunit airspace)
+else()
+  message(WARNING "Cppunit was not found and we could not compile it "
+                  "automatically ourselves. Unit testing will be disabled.")
 endif()
-
-target_link_libraries(MainTest cppunit airspace)
 
 # vim: expandtab

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON
+        LOG_INSTALL ON
         )
 
     ExternalProject_Get_Property(cppunit_external install_dir)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    # When building with Clang, we need to compile cppunit ourselves or we get
-    # linking errors...
+if(NOT CPPUNIT OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # When cppunit was not found, or when building with Clang, we need to
+    # compile cppunit ourselves.
     include(ExternalProject)
     ExternalProject_Add(
         cppunit_external

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
     ExternalProject_Get_Property(cppunit_external install_dir)
     add_library(cppunit STATIC IMPORTED)
     set_property(TARGET cppunit PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libcppunit.a)
+    include_directories("${install_dir}/include")
 
     # Flag that cppunit will be available.
     set(CPPUNIT True)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,9 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
     ExternalProject_Get_Property(cppunit_external install_dir)
     add_library(cppunit STATIC IMPORTED)
     set_property(TARGET cppunit PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libcppunit.a)
+
+    # Flag that cppunit will be available.
+    set(CPPUNIT True)
 endif()
 
 if(CPPUNIT)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
-if(NOT CPPUNIT OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    # When cppunit was not found, or when building with Clang, we need to
-    # compile cppunit ourselves.
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # When building with Clang, we need to compile cppunit ourselves or we get
+    # linking errors...
     include(ExternalProject)
     ExternalProject_Add(
         cppunit_external

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,7 +25,10 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
     ExternalProject_Get_Property(cppunit_external install_dir)
     add_library(cppunit STATIC IMPORTED)
     set_property(TARGET cppunit PROPERTY IMPORTED_LOCATION ${install_dir}/lib/libcppunit.a)
-    include_directories("${install_dir}/include")
+    # Make sure to put SYSTEM in the following command! It will make the
+    # compiler consider the cppunit headers system headers, which makes them
+    # immune against certain warnings. See http://stackoverflow.com/questions/3371127/use-isystem-instead-of-i-with-cmake
+    include_directories(SYSTEM "${install_dir}/include")
 
     # Flag that cppunit will be available.
     set(CPPUNIT True)


### PR DESCRIPTION
This branch contains the following changes:
 - Some cleanup of the compiler selection (no longer force compilers, but only set a set of options, based on the selected compiler). When using clang, cppunit is pulled in as an external project. This should fix #133 and #135. 
 - I replaced the usage of `optparse.h` by a simpler way of parsing command line options. As a result oaconvert can now be compiled on Windows using Visual Studio as well.
 - Compiling unit tests now depends on the presence of cppunit.
 - Creating targets for source code formatting depends on whether astyle could be found.