### PR TITLE
More altitude tokens and cross platform compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,10 @@ cmake_minimum_required(VERSION 2.6)
 project(oaconvert)
 
 # Uncomment this to use clang for compiling.
-SET (CMAKE_CXX_COMPILER "/usr/bin/clang++-3.5")
+#SET (CMAKE_CXX_COMPILER "/usr/bin/clang++-3.5")
 
-set(CMAKE_CXX_FLAGS "-std=c++14 -stdlib=libc++ -g")
+#set(CMAKE_CXX_FLAGS "-std=c++14 -stdlib=libc++ -g")
+set(CMAKE_CXX_FLAGS "-std=c++14 ")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Weffc++ -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wabi -Wmissing-declarations -Wconversion -Wcast-align -Wredundant-decls -Werror -pedantic")
 
 add_subdirectory(src)

--- a/openair/australia/README.TXT
+++ b/openair/australia/README.TXT
@@ -1,0 +1,5 @@
+AIP for Australia are available at http://xcaustralia.org/download/
+
+
+
+

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -33,7 +33,7 @@ const int NBPOINTS = 100;
 // TODO: find a good value for RESOLUTION that leads to nice results.  The
 // smallest circle I have encountered so far is EHD 61 from the Netherlands and
 // it has a radius of 300m.
-const double RESOLUTION = 0.5;
+const double RESOLUTION = 20; //0.5;
 }
 
 #endif /* CONSTANTS_H */

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -192,7 +192,7 @@ double Parser::parseAltitude(const std::string& s) const
     // AGL means 'Above Ground Level', which means that this altitude is measured
     // with respect to the underlying ground surface.
     //
-    // See also:
+    // See also:incorrect altitude
     //   http://en.wikipedia.org/wiki/Above_ground_level
     //
     // Examples:
@@ -291,6 +291,18 @@ double Parser::parseAltitude(const std::string& s) const
     {
         return -1.0; // TODO: handle 'Ask on...'
     }
+
+    if ( regex_match(s, matches, regexMap.find(REGEX_NOTAM)->second) )
+    {
+        return -1.0; // TODO: handle 'NOTAM ...'
+    }
+
+    if ( regex_match(s, matches, regexMap.find(REGEX_CTA)->second) )
+    {
+        return -1.0; // TODO: handle 'CTA ...'
+    }
+
+
 
     cerr << "ERROR: incorrect altitude specification: " << s << endl;
     exit(EXIT_FAILURE);
@@ -529,6 +541,9 @@ void Parser::initRegexMap()
     regexMap[REGEX_AIRSPACE_FLOOR] = regex("\\s*Airspace\\s*Floor.*",          std::regex_constants::icase);
     regexMap[REGEX_UNLIMITED]      = regex("\\s*UNL.*",                        std::regex_constants::icase);
     regexMap[REGEX_ASK]            = regex("\\s*Ask.*",                        std::regex_constants::icase);
+    regexMap[REGEX_NOTAM]          = regex("\\s*NOTAM.*",                      std::regex_constants::icase);
+    regexMap[REGEX_CTA]            = regex("\\s*CTA.*",                      std::regex_constants::icase);
+
     regexMap[REGEX_COMMENT]        = "\\s*\\*.*";
 
     // Valid airspace classes.  Although not specified in the OpenAir specs at

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -73,7 +73,9 @@ private:
         REGEX_DA,
         REGEX_DB,
         REGEX_DB_COORDS,
-        REGEX_DC
+        REGEX_DC,
+        REGEX_NOTAM,
+        REGEX_CTA
     };
 
 private:

--- a/src/oaconvert.cpp
+++ b/src/oaconvert.cpp
@@ -29,6 +29,40 @@
 
 using namespace std;
 
+static std::istream& safeGetline(std::istream& is, std::string& t)
+{
+    t.clear();
+
+    // The characters in the stream are read one-by-one using a std::streambuf.
+    // That is faster than reading them one-by-one using the std::istream.
+    // Code that uses streambuf this way must be guarded by a sentry object.
+    // The sentry object performs various tasks,
+    // such as thread synchronization and updating the stream state.
+
+    std::istream::sentry se(is, true);
+    std::streambuf* sb = is.rdbuf();
+
+    for(;;) {
+        int c = sb->sbumpc();
+        switch (c) {
+        case '\n':
+            return is;
+        case '\r':
+            if(sb->sgetc() == '\n')
+                sb->sbumpc();
+            return is;
+        case EOF:
+            // Also handle the case when the last line has no line ending
+            if(t.empty())
+                is.setstate(std::ios::eofbit);
+            return is;
+        default:
+            t += static_cast<char> (c);
+        }
+    }
+}
+
+
 int main (int argc, char* argv[])
 {
 
@@ -152,7 +186,7 @@ int main (int argc, char* argv[])
     {
         while ( inStream.good() )
         {
-            getline(inStream, line);
+            safeGetline(inStream, line);
             p->handleLine(line);
         }
 


### PR DESCRIPTION
The original version was not working with my Australian airspace file. The reason is it contains NOTAM and CTR in altitude which caused an error. Another thing is that teh txt file might be from DOS which includes LFCR at the end instead of \n. So I added a save readline which distinguishes between DOS and UNIX endlines. Tested and worked with both file versions. (checked with dos2unix and unix2dos for the input file)
